### PR TITLE
force re-add the is_admin and is_project_manager properties

### DIFF
--- a/generated/harvest-openapi.yaml
+++ b/generated/harvest-openapi.yaml
@@ -1837,6 +1837,14 @@ components:
           description: 'Date and time the user was last updated.'
           nullable: true
           format: date-time
+        is_admin:
+          type: boolean
+          description: 'Whether the user has Admin permissions.'
+          nullable: true
+        is_project_manager:
+          type: boolean
+          description: 'Whether the user has Project Manager permissions.'
+          nullable: true
     ExpenseReportsResult:
       type: object
       externalDocs:

--- a/src/Dumper/Dumper.php
+++ b/src/Dumper/Dumper.php
@@ -118,6 +118,20 @@ class Dumper
                     ],
                 ],
             ],
+            'User' => [
+                'properties' => [
+                    'is_admin' => [
+                        'type' => 'boolean',
+                        'description' => 'Whether the user has Admin permissions.',
+                        'nullable' => true,
+                    ],
+                    'is_project_manager' => [
+                        'type' => 'boolean',
+                        'description' => 'Whether the user has Project Manager permissions.',
+                        'nullable' => true,
+                    ],
+                ],
+            ],
         ];
         $warnings = [];
 


### PR DESCRIPTION
These properties are not documented anymore, but are still available in API responses.